### PR TITLE
Add end sync argument

### DIFF
--- a/FFmpeg.py
+++ b/FFmpeg.py
@@ -23,11 +23,12 @@ SOFTWARE.
 """
 
 
-import config 
+import config
 import subprocess
 import json
 import os
 from ffmpeg_progress_yield import FfmpegProgress
+
 
 class FFprobe:
     '''
@@ -42,7 +43,8 @@ class FFprobe:
         - getPacketsInfo()
     '''
     cmd = config.ffprobe
-    def __init__ (self, videoSrc, loglevel = "info"):
+
+    def __init__(self, videoSrc, loglevel="info"):
         self.videoSrc = videoSrc
         self.loglevel = loglevel
         self.streamInfo = None
@@ -50,25 +52,27 @@ class FFprobe:
         self.packetsInfo = None
 
     ''' private methods '''
+
     def _commit(self, opt):
-        self.cmd =  f'{FFprobe.cmd} -hide_banner -loglevel {self.loglevel} -print_format json {opt} -select_streams v -i \"{self.videoSrc}\" -read_intervals %+5'
-    
+        self.cmd = f'{FFprobe.cmd} -hide_banner -loglevel {self.loglevel} -print_format json {opt} -select_streams v -i \"{self.videoSrc}\" -read_intervals %+5'
+
     def _run(self):
         if self.loglevel == "verbose":
             print(self.cmd, flush=True)
         return json.loads(subprocess.check_output(self.cmd, shell=True))
-    
+
     ''' public methods '''
+
     def getStreamInfo(self):
         self._commit('-show_streams')
         self.streamInfo = self._run()['streams'][0]
         return self.streamInfo
-    
+
     def getFramesInfo(self):
         self._commit('-show_frames')
         self.framesInfo = self._run()['frames']
         return self.framesInfo
-    
+
     def getPacketsInfo(self):
         self._commit('-show_packets')
         self.packetsInfo = self._run()['packets']
@@ -77,8 +81,8 @@ class FFprobe:
     def getFormatInfo(self):
         self._commit('-show_format')
         self.packetsInfo = self._run()['format']
-        return self.packetsInfo 
-        
+        return self.packetsInfo
+
 
 class FFmpegQos:
     '''
@@ -87,11 +91,11 @@ class FFmpegQos:
     '''
     cmd = config.ffmpeg
 
-    def __init__ (self,  main, ref , loglevel = "info"):
+    def __init__(self,  main, ref, loglevel="info"):
         self.loglevel = loglevel
         self.cmd = None
-        self.main = inputFFmpeg(main, input_id =0)
-        self.ref = inputFFmpeg(ref, input_id =1)
+        self.main = inputFFmpeg(main, input_id=0)
+        self.ref = inputFFmpeg(ref, input_id=1)
         self.psnrFilter = []
         self.vmafFilter = []
         self.invertedSrc = False
@@ -108,17 +112,17 @@ class FFmpegQos:
     def _commitInputs(self):
         """build the cmd for the inputs files"""
         inputCmd = f'-i \"{self.main.videoSrc}\" -i \"{self.ref.videoSrc}\" -map 0:v -map 1:v'
-        return  inputCmd
+        return inputCmd
 
     def _commitOutputs(self):
         return "-f null -"
 
-    def _commitFilters(self, filterName = 'lavfi'):
+    def _commitFilters(self, filterName='lavfi'):
         """build the cmd for the filters"""
         filterCmd = f'-{filterName} \"{";".join(self.main.filtersList + self.ref.filtersList + self.psnrFilter + self.vmafFilter)}\"'
         return filterCmd
 
-    def getPsnr(self, stats_file = False):
+    def getPsnr(self, stats_file=False):
         """ 
         It adds PSNR filter to lavfi chain and run the ffmpeg cmd.
         The output is returned and saved as stats_file_psnr.log
@@ -126,78 +130,80 @@ class FFmpegQos:
         main = self.main.lastOutputID
         ref = self.ref.lastOutputID
         if stats_file == True:
-            stats_file = os.path.splitext(self.main.videoSrc)[0]+ '_psnr.log'
-        else: stats_file = 'stats_file_psnr.log'
+            stats_file = os.path.splitext(self.main.videoSrc)[0] + '_psnr.log'
+        else:
+            stats_file = 'stats_file_psnr.log'
 
-        self.psnrFilter = [f'[{main}][{ref}]psnr=stats_file={stats_file}']       
+        self.psnrFilter = [f'[{main}][{ref}]psnr=stats_file={stats_file}']
         self._commit()
 
-        if self.loglevel == "verbose": print(self.cmd, flush=True)
-        stdout = (subprocess.check_output(self.cmd,stderr=subprocess.STDOUT, shell=True)).decode('utf-8')
+        if self.loglevel == "verbose":
+            print(self.cmd, flush=True)
+        stdout = (subprocess.check_output(
+            self.cmd, stderr=subprocess.STDOUT, shell=True)).decode('utf-8')
         stdout = stdout.split(" ")
         psnr = [s for s in stdout if "average" in s][0].split(":")[1]
         return float(psnr)
 
-
-    def getVmaf(self, log_path= None, model= 'HD', phone = False, subsample = 1,output_fmt='json', threads = 0, print_progress = False ):
+    def getVmaf(self, log_path=None, model='HD', phone=False, subsample=1, output_fmt='json', threads=0, print_progress=False, end_sync=False):
         main = self.main.lastOutputID
         ref = self.ref.lastOutputID
-        if output_fmt=='xml':
+        if output_fmt == 'xml':
             log_fmt = "xml"
             if log_path == None:
-                log_path = os.path.splitext(self.main.videoSrc)[0]+ '_vmaf.xml'
+                log_path = os.path.splitext(self.main.videoSrc)[
+                    0] + '_vmaf.xml'
         else:
             log_fmt = "json"
             if log_path == None:
-                log_path = os.path.splitext(self.main.videoSrc)[0]+ '_vmaf.json'
+                log_path = os.path.splitext(self.main.videoSrc)[
+                    0] + '_vmaf.json'
         self.vmafpath = log_path
-        if model =='HD': 
+        if model == 'HD':
             model_path = config.vmaf_HD
-            phone_model = int (phone)
-        elif model =='HDneg': 
+            phone_model = int(phone)
+        elif model == 'HDneg':
             model_path = config.vmaf_HDneg
-            phone_model = int (phone)
-        elif model == '4K': 
+            phone_model = int(phone)
+        elif model == '4K':
             model_path = config.vmaf_4K
             phone_model = 0
-        if threads == 0: threads = os.cpu_count()
+        if threads == 0:
+            threads = os.cpu_count()
 
-        self.vmafFilter = [f'[{main}][{ref}]libvmaf=log_fmt={log_fmt}:model_path={model_path}:phone_model={phone_model}:n_subsample={subsample}:log_path={log_path}:n_threads={threads}']
+        self.vmafFilter = [f'[{main}][{ref}]libvmaf=log_fmt={log_fmt}:model_path={model_path}:phone_model={phone_model}:n_subsample={subsample}:log_path={log_path}:n_threads={threads}:shortest=1' if end_sync else f'[{main}][{ref}]libvmaf=log_fmt={log_fmt}:model_path={model_path}:phone_model={phone_model}:n_subsample={subsample}:log_path={log_path}:n_threads={threads}']
 
         self._commit()
-        if self.loglevel == "verbose": print(self.cmd, flush=True)
-    
+        if self.loglevel == "verbose":
+            print(self.cmd, flush=True)
+
         if print_progress:
-            cmd_progress =[]
+            cmd_progress = []
             cmd_fancy = " ".join(self.cmd.split())
             cmd_fancy = cmd_fancy.split(' ')
-            [ cmd_progress.append(i.strip('"')) for i in cmd_fancy] 
-            print (cmd_fancy,cmd_progress)
+            [cmd_progress.append(i.strip('"')) for i in cmd_fancy]
+            print(cmd_fancy, cmd_progress)
             process = FfmpegProgress(cmd_progress)
             for progress in process.run_command_with_progress():
-                print(f"progress = {progress}% - ", "\n".join(process.stderr.splitlines()[-9:-8]))
-
-                
+                print(f"progress = {progress}% - ",
+                      "\n".join(process.stderr.splitlines()[-9:-8]))
 
         else:
-            process = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, shell=True)
+            process = subprocess.Popen(
+                self.cmd, stdout=subprocess.PIPE, shell=True)
             process.communicate()
 
         return process
 
-
-
-
-    
     def clearFilters(self):
         self.psnrFilter = []
-        self.vmafFilter = []      
+        self.vmafFilter = []
 
     def invertSrcs(self):
         temp1 = self.main.videoSrc
         temp2 = self.ref.videoSrc
         invertedSrc = self.invertedSrc
-        self.__init__(temp2,temp1, self.loglevel)
+        self.__init__(temp2, temp1, self.loglevel)
         self.invertedSrc = not (invertedSrc)
 
 
@@ -214,31 +220,32 @@ class inputFFmpeg:
     - setFpsFilter()
     - clearFilters()
     '''
-    def __init__(self, videoSrc, input_id ):
+
+    def __init__(self, videoSrc, input_id):
         self.name = f'input{input_id}_'
         self.id = input_id
         self.videoSrc = videoSrc
-        self.filtersList =[]
+        self.filtersList = []
         self.extraOptions = []
-        self.lastOutputID =  f'{str(self.id)}:v'
+        self.lastOutputID = f'{str(self.id)}:v'
 
-    def _setFilter(self,filter):
+    def _setFilter(self, filter):
         self.filtersList.append(filter)
 
     def _newInOutForFilter(self):
         self.n = len(self.filtersList)
         if self.n == 0:
             inputID = f'{str(self.id)}:v'
-            outputID = f'{self.name}{str(self.n)}' 
+            outputID = f'{self.name}{str(self.n)}'
         else:
-            inputID =  f'{self.name}{str(self.n-1)}'
+            inputID = f'{self.name}{str(self.n-1)}'
             outputID = f'{self.name}{str(self.n)}'
         return inputID, outputID
 
-    def _updateOutputId(self, outputID ):
+    def _updateOutputId(self, outputID):
         self.lastOutputID = outputID
-    
-    def setScaleFilter(self, width, height, algo = 'bicubic'):
+
+    def setScaleFilter(self, width, height, algo='bicubic'):
         """Filter options for Upscale or Downscale"""
         inputID, outputID = self._newInOutForFilter()
         scaleFilter = f'[{inputID}]scale={width}:{height}:flags={algo}[{outputID}]'
@@ -275,16 +282,16 @@ class inputFFmpeg:
     def setTrimFilter(self, start, duration):
         inputID, outputID = self._newInOutForFilter()
         trimFilter = f'[{inputID}]trim=start={start}:duration={duration}, setpts=PTS-STARTPTS[{outputID}]'
-        self._setFilter(trimFilter) 
+        self._setFilter(trimFilter)
         self._updateOutputId(outputID)
-        return 
+        return
 
     def setFpsFilter(self, fps):
         inputID, outputID = self._newInOutForFilter()
         fpsFilter = f'[{inputID}]fps=fps={fps}[{outputID}]'
         self._setFilter(fpsFilter)
         self._updateOutputId(outputID)
-    
+
     def clearFilters(self):
-        self.filtersList =[]
-        self.lastOutputID =  f'{str(self.id)}:v'
+        self.filtersList = []
+        self.lastOutputID = f'{str(self.id)}:v'

--- a/Vmaf.py
+++ b/Vmaf.py
@@ -30,7 +30,8 @@ class video():
     Video class to parse information of video streams obtained
     by _FFmpeg.FFprobe
     """
-    def __init__(self, videoSrc, loglevel = "info"):
+
+    def __init__(self, videoSrc, loglevel="info"):
         self.videoSrc = videoSrc
         self.streamInfo = None
         self.framesInfo = None
@@ -48,61 +49,62 @@ class video():
 
     def _updateFramesSummary(self):
         interlacedFrames_count = 0
-        bytesFramesTotal =0
-        if self.framesInfo == None: return
+        bytesFramesTotal = 0
+        if self.framesInfo == None:
+            return
         for frame in self.framesInfo:
-            interlacedFrames_count = interlacedFrames_count + int(frame['interlaced_frame'])
+            interlacedFrames_count = interlacedFrames_count + \
+                int(frame['interlaced_frame'])
             bytesFramesTotal = bytesFramesTotal + int(frame['pkt_size'])
         self.interlacedFrames = interlacedFrames_count
         self.totalFrames = len(self.framesInfo)
         self.bytesFramesTotal = bytesFramesTotal
-        if int(round (self.interlacedFrames/self.totalFrames)): 
-            self.interlaced= True
-        else: 
-            self.interlaced= False
+        if int(round(self.interlacedFrames/self.totalFrames)):
+            self.interlaced = True
+        else:
+            self.interlaced = False
         return
 
     def getDuration(self):
         try:
-            duration = round(float(self.streamInfo['duration'])-float(self.streamInfo['start_time']))
+            duration = round(
+                float(self.streamInfo['duration'])-float(self.streamInfo['start_time']))
             if duration < 0:
                 duration = round(float(self.streamInfo['duration']))
         except KeyError:
-            duration = round(float(self.formatInfo['duration'])-float(self.formatInfo['start_time']))
+            duration = round(
+                float(self.formatInfo['duration'])-float(self.formatInfo['start_time']))
             if duration < 0:
                 duration = round(float(self.formatInfo['duration']))
         return duration
 
-
     def getStreamInfo(self):
         print("\n\n=======================================", flush=True)
-        print("[easyVmaf] Getting stream info...", self.videoSrc ,flush=True)
+        print("[easyVmaf] Getting stream info...", self.videoSrc, flush=True)
         print("=======================================", flush=True)
 
-        
         self.streamInfo = FFprobe(self.videoSrc, self.loglevel).getStreamInfo()
         return self.streamInfo
-    
+
     def getFramesInfo(self):
         print("\n\n=======================================", flush=True)
-        print("[easyVmaf] Getting frames info...", self.videoSrc ,flush=True)
+        print("[easyVmaf] Getting frames info...", self.videoSrc, flush=True)
         print("=======================================", flush=True)
         self.framesInfo = FFprobe(self.videoSrc, self.loglevel).getFramesInfo()
         self._updateFramesSummary()
         return self.framesInfo
 
-
     def getPacketsInfo(self):
         print("\n\n=======================================", flush=True)
-        print("[easyVmaf] Getting packets info...", self.videoSrc ,flush=True)
+        print("[easyVmaf] Getting packets info...", self.videoSrc, flush=True)
         print("=======================================", flush=True)
-        self.packetsInfo = FFprobe(self.videoSrc, self.loglevel).getPacketsInfo()
+        self.packetsInfo = FFprobe(
+            self.videoSrc, self.loglevel).getPacketsInfo()
         return self.packetsInfo
 
-    
     def getFormatInfo(self):
         print("\n\n=======================================", flush=True)
-        print("[easyVmaf] Getting format info...", self.videoSrc ,flush=True)
+        print("[easyVmaf] Getting format info...", self.videoSrc, flush=True)
         print("=======================================", flush=True)
         self.formatInfo = FFprobe(self.videoSrc, self.loglevel).getFormatInfo()
         return self.formatInfo
@@ -116,20 +118,23 @@ class vmaf():
         - To SYNC (in time) the MAIN and REF videos using psnr computation 
         - Frame rate conversion (if needed)
     """
-    def __init__(self, mainSrc, refSrc,output_fmt, model = "HD", phone = False, loglevel = "info", subsample = 1, threads = 0, print_progress=False):
+
+    def __init__(self, mainSrc, refSrc, output_fmt, model="HD", phone=False, loglevel="info", subsample=1, threads=0, print_progress=False, end_sync=False):
         self.loglevel = loglevel
-        self.main = video(mainSrc,self.loglevel)
-        self.ref = video(refSrc,self.loglevel)
+        self.main = video(mainSrc, self.loglevel)
+        self.ref = video(refSrc, self.loglevel)
         self.model = model
         self.phone = phone
         self.subsample = subsample
-        self.ffmpegQos = FFmpegQos(self.main.videoSrc, self.ref.videoSrc, self.loglevel)
+        self.ffmpegQos = FFmpegQos(
+            self.main.videoSrc, self.ref.videoSrc, self.loglevel)
         self.target_resolution = None
         self.offset = 0
         self._initResolutions()
         self.output_fmt = output_fmt
         self.threads = threads
         self.print_progress = print_progress
+        self.end_sync = end_sync
 
     def _initResolutions(self):
         """ 
@@ -138,128 +143,143 @@ class vmaf():
         if self.model == 'HD' or self.model == 'HDneg':
             self.target_resolution = [1920, 1080]
         elif self.model == '4K':
-            self.target_resolution = [3840,2160]
+            self.target_resolution = [3840, 2160]
         else:
             exit("[easyVmaf] ERROR: Invalid vmaf model")
-
 
     def _autoScale(self):
         """ 
         scaling MAIN and REF if they dont match with the resolution requiered by the vmaf model (target resolution)
         """
-        refResolution = [self.ref.streamInfo['width'], self.ref.streamInfo['height']]
-        mainResolution = [self.main.streamInfo['width'], self.main.streamInfo['height']]
+        refResolution = [self.ref.streamInfo['width'],
+                         self.ref.streamInfo['height']]
+        mainResolution = [self.main.streamInfo['width'],
+                          self.main.streamInfo['height']]
         if refResolution != self.target_resolution:
             if not self.ffmpegQos.invertedSrc:
-                self.ffmpegQos.ref.setScaleFilter(self.target_resolution[0], self.target_resolution[1])
+                self.ffmpegQos.ref.setScaleFilter(
+                    self.target_resolution[0], self.target_resolution[1])
             if self.ffmpegQos.invertedSrc:
-                self.ffmpegQos.main.setScaleFilter(self.target_resolution[0], self.target_resolution[1])
-                   
+                self.ffmpegQos.main.setScaleFilter(
+                    self.target_resolution[0], self.target_resolution[1])
+
         if mainResolution != self.target_resolution:
             if not self.ffmpegQos.invertedSrc:
-                self.ffmpegQos.main.setScaleFilter(self.target_resolution[0], self.target_resolution[1])
+                self.ffmpegQos.main.setScaleFilter(
+                    self.target_resolution[0], self.target_resolution[1])
             if self.ffmpegQos.invertedSrc:
-                self.ffmpegQos.ref.setScaleFilter(self.target_resolution[0], self.target_resolution[1])
-
+                self.ffmpegQos.ref.setScaleFilter(
+                    self.target_resolution[0], self.target_resolution[1])
 
     def _deinterlaceFrame(self, factor, stream):
         ref_fps = getFrameRate(self.ref.streamInfo['r_frame_rate'])
         main_fps = getFrameRate(self.main.streamInfo['r_frame_rate'])
 
         stream.setDeintFrameFilter()
-        if round(ref_fps,2)!=round(factor*main_fps,2):
-            stream.setFpsFilter(round(main_fps,5))
-      
+        if round(ref_fps, 2) != round(factor*main_fps, 2):
+            stream.setFpsFilter(round(main_fps, 5))
 
     def _deinterlaceField(self, factor, stream):
-        
+
         ref_fps = getFrameRate(self.ref.streamInfo['r_frame_rate'])
         main_fps = getFrameRate(self.main.streamInfo['r_frame_rate'])
 
-        stream.setDeintFieldFilter()            
-        if round(ref_fps,2)!=round(factor*main_fps,2):
-            stream.setFpsFilter(round(main_fps,5))
-        
+        stream.setDeintFieldFilter()
+        if round(ref_fps, 2) != round(factor*main_fps, 2):
+            stream.setFpsFilter(round(main_fps, 5))
 
     def _autoDeinterlace(self):
-
         """ 
         This functions normalizes the framerate between MAIN and REF video streams (if needed)
         """
         ref_fps = getFrameRate(self.ref.streamInfo['r_frame_rate'])
         main_fps = getFrameRate(self.main.streamInfo['r_frame_rate'])
 
-        if self.ref.interlaced ==  self.main.interlaced : 
+        if self.ref.interlaced == self.main.interlaced:
             """ Not Deinterlace would be required. So this functions normalizes the fps between REF and MAIN
             """
-            if round(ref_fps ) < round(main_fps):
+            if round(ref_fps) < round(main_fps):
                 """
                 frame rate conversion over MAIN video. The lowest framerate is choosed (REF fps).
                 """
-                print("[easyVmaf] Warning: Frame rate conversion can produce bad vmaf scores", flush=True)
-                self.ffmpegQos.main.setFpsFilter(round(ref_fps,5))
-            elif round(ref_fps ) > round(main_fps):
+                print(
+                    "[easyVmaf] Warning: Frame rate conversion can produce bad vmaf scores", flush=True)
+                self.ffmpegQos.main.setFpsFilter(round(ref_fps, 5))
+            elif round(ref_fps) > round(main_fps):
                 """
                 frame rate conversion over REF video. The lowest framerate is choosed (MAIN fps).
                 """
-                print("[easyVmaf] Warning: Frame rate conversion can produce bad vmaf scores", flush=True)
-                self.ffmpegQos.ref.setFpsFilter(round(main_fps,5))
+                print(
+                    "[easyVmaf] Warning: Frame rate conversion can produce bad vmaf scores", flush=True)
+                self.ffmpegQos.ref.setFpsFilter(round(main_fps, 5))
             else:
                 """
                 This just pass the original framerate to the ffmpeg filter (lavfi) when no frame rate
                 conversion is requiered. For some reason it is mandatory by lavfi in order to work properly.
                 """
 
-                self.ffmpegQos.main.setFpsFilter(round(main_fps,5))
-                self.ffmpegQos.ref.setFpsFilter(round(ref_fps,5))
+                self.ffmpegQos.main.setFpsFilter(round(main_fps, 5))
+                self.ffmpegQos.ref.setFpsFilter(round(ref_fps, 5))
 
-        elif self.ref.interlaced and not self.main.interlaced :
+        elif self.ref.interlaced and not self.main.interlaced:
             """ 
             REF interlaced  | MAIN progressive
-            """ 
-            if round(ref_fps ) == round(main_fps*2): 
+            """
+            if round(ref_fps) == round(main_fps*2):
                 # Examples: REF=60i, MAIN=30p
                 # REF=59.97i, MAIN=30p, etc
-                if not self.ffmpegQos.invertedSrc: self._deinterlaceFrame(2, self.ffmpegQos.ref )
-                else: self._deinterlaceFrame(2, self.ffmpegQos.main )
+                if not self.ffmpegQos.invertedSrc:
+                    self._deinterlaceFrame(2, self.ffmpegQos.ref)
+                else:
+                    self._deinterlaceFrame(2, self.ffmpegQos.main)
 
-            elif round(ref_fps) == round(main_fps): 
+            elif round(ref_fps) == round(main_fps):
                 # Examples: REF=30i, MAIN=30p
                 # REF=29.97i, MAIN=30p, etc
-                if not self.ffmpegQos.invertedSrc: self._deinterlaceFrame(1, self.ffmpegQos.ref )
-                else: self._deinterlaceFrame(1, self.ffmpegQos.main )
+                if not self.ffmpegQos.invertedSrc:
+                    self._deinterlaceFrame(1, self.ffmpegQos.ref)
+                else:
+                    self._deinterlaceFrame(1, self.ffmpegQos.main)
 
-            elif round(ref_fps) == round(main_fps/2): 
+            elif round(ref_fps) == round(main_fps/2):
                 # Examples: REF=30i, MAIN=60p
                 # REF=29.97i, MAIN=60p, etc
-                if not self.ffmpegQos.invertedSrc: self._deinterlaceField(0.5, self.ffmpegQos.ref )
-                else: self._deinterlaceField(0.5, self.ffmpegQos.main )
-            
+                if not self.ffmpegQos.invertedSrc:
+                    self._deinterlaceField(0.5, self.ffmpegQos.ref)
+                else:
+                    self._deinterlaceField(0.5, self.ffmpegQos.main)
+
             else:
-                print("[easyVmaf] ERROR: No Filters available for the given Framerates", flush=True)
+                print(
+                    "[easyVmaf] ERROR: No Filters available for the given Framerates", flush=True)
 
         elif not self.ref.interlaced and self.main.interlaced:
             """ 
             Input Progressive (REF) | Output Interlaced (MAIN)
             """
-            if round(ref_fps ) == round(main_fps*2):
+            if round(ref_fps) == round(main_fps*2):
                 # Examples: REF=60p, MAIN=30i
                 # REF=60p, MAIN=29.97i, etc
-                print("[easyVmaf] Warning: Frame rate conversion can produce bad vmaf scores", flush=True)
-                if not self.ffmpegQos.invertedSrc: self._deinterlaceField(1, self.ffmpegQos.main)
-                else: self._deinterlaceField(1, self.ffmpegQos.ref)
+                print(
+                    "[easyVmaf] Warning: Frame rate conversion can produce bad vmaf scores", flush=True)
+                if not self.ffmpegQos.invertedSrc:
+                    self._deinterlaceField(1, self.ffmpegQos.main)
+                else:
+                    self._deinterlaceField(1, self.ffmpegQos.ref)
 
-            elif round(ref_fps ) == round(main_fps):
+            elif round(ref_fps) == round(main_fps):
                 # Examples: REF=30p, MAIN=30i
                 # REF=30p, MAIN=29.97i, etc
-                if not self.ffmpegQos.invertedSrc: self._deinterlaceFrame(1, self.ffmpegQos.main)
-                else: self._deinterlaceFrame(1, self.ffmpegQos.ref)
+                if not self.ffmpegQos.invertedSrc:
+                    self._deinterlaceFrame(1, self.ffmpegQos.main)
+                else:
+                    self._deinterlaceFrame(1, self.ffmpegQos.ref)
 
             else:
-                print("[easyVmaf] ERROR: No Filters available for the given Framerates", flush=True)
+                print(
+                    "[easyVmaf] ERROR: No Filters available for the given Framerates", flush=True)
 
-            
-    def syncOffset(self, syncWindow = 3, start=0, reverse = False):
+    def syncOffset(self, syncWindow=3, start=0, reverse=False):
         """
         Method to get the offset needed to sync REF and MAIN (if any). 
             syncWindow -->  Window Size in seconds to try to sync REF and MAIN videos. i.e., if the video to sync
@@ -277,31 +297,32 @@ class vmaf():
         print("\n\n=======================================", flush=True)
         print("Syncing... Computing PSNR values... ", flush=True)
         print("=======================================", flush=True)
-        print("Distorted:" , self.main.videoSrc , "@" , round(getFrameRate(self.main.streamInfo['r_frame_rate']),5) , "fps","|" ,self.main.streamInfo['width'], self.main.streamInfo['height'] , flush=True)
-        print("Reference:" , self.ref.videoSrc , "@" , round(getFrameRate(self.ref.streamInfo['r_frame_rate']),5) , "fps","|" ,self.ref.streamInfo['width'], self.ref.streamInfo['height'],  flush=True)
+        print("Distorted:", self.main.videoSrc, "@", round(getFrameRate(
+            self.main.streamInfo['r_frame_rate']), 5), "fps", "|", self.main.streamInfo['width'], self.main.streamInfo['height'], flush=True)
+        print("Reference:", self.ref.videoSrc, "@", round(getFrameRate(
+            self.ref.streamInfo['r_frame_rate']), 5), "fps", "|", self.ref.streamInfo['width'], self.ref.streamInfo['height'],  flush=True)
         print("=======================================", flush=True)
-        print("offset(s)","\t\t","psnr[dB]", flush=True)
+        print("offset(s)", "\t\t", "psnr[dB]", flush=True)
 
-
-        if reverse: self.ffmpegQos.invertSrcs()
+        if reverse:
+            self.ffmpegQos.invertSrcs()
         fps = getFrameRate(self.ref.streamInfo['r_frame_rate'])
         frameDuration = 1/fps
         startFrame = int(round(start/frameDuration))
         framesInSyncWindow = int(round(syncWindow/frameDuration))
-        psnr ={'value':[], 'time':[]}
+        psnr = {'value': [], 'time': []}
 
-
-        for i in range(0,framesInSyncWindow ):
+        for i in range(0, framesInSyncWindow):
             offset = (startFrame + i) * frameDuration
             self.ffmpegQos.main.clearFilters()
             self.ffmpegQos.ref.clearFilters()
-            self.ffmpegQos.ref.setTrimFilter(offset, 0.5 )
-            self.ffmpegQos.main.setTrimFilter(0, 0.5 )
+            self.ffmpegQos.ref.setTrimFilter(offset, 0.5)
+            self.ffmpegQos.main.setTrimFilter(0, 0.5)
             self._autoScale()
             self._autoDeinterlace()
             psnr['value'].append(self.ffmpegQos.getPsnr())
             psnr['time'].append(offset)
-            print (psnr['time'][i], "\t", psnr['value'][i], flush= True)
+            print(psnr['time'][i], "\t", psnr['value'][i], flush=True)
 
         maxPsnr = max(psnr['value'])
         index = psnr['value'].index(maxPsnr)
@@ -319,7 +340,6 @@ class vmaf():
 
         return [self.offset, maxPsnr]
 
-
     def setOffset(self, value=None):
         """
         Apply Offset to trim Filter. 
@@ -334,23 +354,21 @@ class vmaf():
         if self.offset > 0:
             offset = self.offset
             duration = min(self.main.duration, self.ref.duration-offset)
-            self.ffmpegQos.ref.setTrimFilter(offset, duration )
-            self.ffmpegQos.main.setTrimFilter(0, duration )
+            self.ffmpegQos.ref.setTrimFilter(offset, duration)
+            self.ffmpegQos.main.setTrimFilter(0, duration)
 
         elif self.offset < 0:
             offset = abs(self.offset)
             duration = min(self.main.duration - offset, self.ref.duration)
-            self.ffmpegQos.main.setTrimFilter(offset, duration )
+            self.ffmpegQos.main.setTrimFilter(offset, duration)
             self.ffmpegQos.ref.setTrimFilter(0, duration)
 
-    def getVmaf(self, autoSync = False):
-
-
+    def getVmaf(self, autoSync=False):
         """ clean all filters first """
         self.ffmpegQos.clearFilters()
         self.ffmpegQos.main.clearFilters()
         self.ffmpegQos.ref.clearFilters()
-        
+
         """AutoScale according to vmaf model and deinterlace the source if needed """
         self._autoScale()
         self._autoDeinterlace()
@@ -358,15 +376,18 @@ class vmaf():
         """Lookup for sync between Main and reference. Default: dissable
            It is suggested to run syncOffset manually before getVmaf()
         """
-        if autoSync: self.syncOffset()
+        if autoSync:
+            self.syncOffset()
         """Apply Offset filters, if offset =0 nothing happens """
         self.setOffset()
 
         print("\n\n=======================================", flush=True)
         print("Computing VMAF... ", flush=True)
         print("=======================================", flush=True)
-        print("Distorted:" , self.main.videoSrc , "@" , round(getFrameRate(self.main.streamInfo['r_frame_rate']),5) , "fps","|" ,self.main.streamInfo['width'], self.main.streamInfo['height'] , flush=True)
-        print("Reference:" , self.ref.videoSrc , "@" , round(getFrameRate(self.ref.streamInfo['r_frame_rate']),5) , "fps","|" ,self.ref.streamInfo['width'], self.ref.streamInfo['height'],  flush=True)
+        print("Distorted:", self.main.videoSrc, "@", round(getFrameRate(
+            self.main.streamInfo['r_frame_rate']), 5), "fps", "|", self.main.streamInfo['width'], self.main.streamInfo['height'], flush=True)
+        print("Reference:", self.ref.videoSrc, "@", round(getFrameRate(
+            self.ref.streamInfo['r_frame_rate']), 5), "fps", "|", self.ref.streamInfo['width'], self.ref.streamInfo['height'],  flush=True)
         print("Offset:", self.offset, flush=True)
         print("Model:", self.model, flush=True)
         print("Phone:", self.phone, flush=True)
@@ -375,7 +396,8 @@ class vmaf():
         print("output_fmt:", self.output_fmt, flush=True)
         print("=======================================", flush=True)
 
-        vmafProcess = self.ffmpegQos.getVmaf(model = self.model, phone = self.phone, subsample= self.subsample, output_fmt=self.output_fmt, threads=self.threads, print_progress= self.print_progress)
+        vmafProcess = self.ffmpegQos.getVmaf(model=self.model, phone=self.phone, subsample=self.subsample,
+                                             output_fmt=self.output_fmt, threads=self.threads, print_progress=self.print_progress, end_sync=self.end_sync)
         return vmafProcess
 
 

--- a/easyVmaf.py
+++ b/easyVmaf.py
@@ -39,33 +39,47 @@ def handler(signal_received, frame):
     print('SIGINT or CTRL-C detected. Exiting gracefully')
     sys.exit(0)
 
+
 def get_args():
     '''This function parses and return arguments passed in'''
-    parser = MyParser(prog='easyVmaf', 
-            description="Script to easy compute VMAF using FFmpeg. It allows to deinterlace, scale and sync Ref and Distorted video samples automatically: \
+    parser = MyParser(prog='easyVmaf',
+                      description="Script to easy compute VMAF using FFmpeg. It allows to deinterlace, scale and sync Ref and Distorted video samples automatically: \
                         \n\n \t Autodeinterlace: If the Reference or Distorted samples are interlaced, deinterlacing is applied\
                         \n\n \t Autoscale: Reference and Distorted samples are scaled automatically to 1920x1080 or 3840x2160 depending on the VMAF model to use\
                         \n\n \t Autosync: The first frames of the distorted video are used as reference to a sync look up with the Reference video. \
                         \n \t \t The sync is doing by a frame-by-frame look up of the best PSNR\
                         \n \t \t See [-reverse] for more options of syncing\
-                        \n\n As output, a json file with VMAF score is created", 
-            epilog="* NOTE: HDneg is a VMAF experimental feature not supported yet by FFmpeg.",
-            formatter_class=argparse.RawTextHelpFormatter)
+                        \n\n As output, a json file with VMAF score is created",
+                      epilog="* NOTE: HDneg is a VMAF experimental feature not supported yet by FFmpeg.",
+                      formatter_class=argparse.RawTextHelpFormatter)
     requiredgroup = parser.add_argument_group('required arguments')
-    requiredgroup.add_argument('-d', dest='d', type=str, help='Distorted video', required=True)
-    requiredgroup.add_argument('-r', dest='r', type=str, help='Reference video ', required=True)
-    parser.add_argument('-sw', dest='sw', type=float, default=0, help='Sync Window: window size in seconds of a subsample of the Reference video. The sync lookup will be done between the first frames of the Distorted input and this Subsample of the Reference. (default=0. No sync).')
-    parser.add_argument('-ss', dest='ss', type=float, default=0, help="Sync Start Time. Time in seconds from the beginning of the Reference video to which the Sync Window will be applied from. (default=0).")
-    parser.add_argument('-subsample', dest='n', type=int, default=1, help="Specifies the subsampling of frames to speed up calculation. (default=1, None).")
+    requiredgroup.add_argument(
+        '-d', dest='d', type=str, help='Distorted video', required=True)
+    requiredgroup.add_argument(
+        '-r', dest='r', type=str, help='Reference video ', required=True)
+    parser.add_argument('-sw', dest='sw', type=float, default=0,
+                        help='Sync Window: window size in seconds of a subsample of the Reference video. The sync lookup will be done between the first frames of the Distorted input and this Subsample of the Reference. (default=0. No sync).')
+    parser.add_argument('-ss', dest='ss', type=float, default=0,
+                        help="Sync Start Time. Time in seconds from the beginning of the Reference video to which the Sync Window will be applied from. (default=0).")
+    parser.add_argument('-subsample', dest='n', type=int, default=1,
+                        help="Specifies the subsampling of frames to speed up calculation. (default=1, None).")
     parser.add_argument('-reverse', help="If enable, it Changes the default Autosync behaviour: The first frames of the Reference video are used as reference to sync with the Distorted one. (Default = Disable).", action='store_true')
-    parser.add_argument('-model', dest='model', type=str, default="HD", help="Vmaf Model. Options: HD, HDneg*, 4K. (Default: HD).")
-    parser.add_argument('-phone', help='It enables vmaf phone model (HD only). (Default=disable).', action='store_true')
-    parser.add_argument('-threads', dest = 'threads', type = int, default=0, help='number of threads')
-    parser.add_argument('-verbose', help='Activate verbose loglevel. (Default: info).', action='store_true')
-    parser.add_argument('-progress', help='Activate progress indicator for vmaf computation. (Default: false).', action='store_true')
+    parser.add_argument('-model', dest='model', type=str, default="HD",
+                        help="Vmaf Model. Options: HD, HDneg*, 4K. (Default: HD).")
+    parser.add_argument(
+        '-phone', help='It enables vmaf phone model (HD only). (Default=disable).', action='store_true')
+    parser.add_argument('-threads', dest='threads', type=int,
+                        default=0, help='number of threads')
+    parser.add_argument(
+        '-verbose', help='Activate verbose loglevel. (Default: info).', action='store_true')
+    parser.add_argument(
+        '-progress', help='Activate progress indicator for vmaf computation. (Default: false).', action='store_true')
+    parser.add_argument(
+        '-endsync', help='Activate end sync. This ends the computation when the shortest video ends. (Default: false).', action='store_true')
 
-    parser.add_argument('-output_fmt', dest='output_fmt',type=str, default='json', help='Output vmaf file format. Options: json or xml (Default: json)')
-    
+    parser.add_argument('-output_fmt', dest='output_fmt', type=str, default='json',
+                        help='Output vmaf file format. Options: json or xml (Default: json)')
+
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
@@ -98,6 +112,7 @@ if __name__ == '__main__':
     output_fmt = cmdParser.output_fmt
     threads = cmdParser.threads
     print_progress = cmdParser.progress
+    end_sync = cmdParser.endsync
 
     # Setting verbosity
     if verbose:
@@ -107,9 +122,9 @@ if __name__ == '__main__':
 
     # check output format
     if not output_fmt in ["json", "xml"]:
-        print("output_fmt: ", output_fmt, " Not supported. JSON output used instead", flush=True)
+        print("output_fmt: ", output_fmt,
+              " Not supported. JSON output used instead", flush=True)
         output_fmt = "json"
-
 
     '''
     Distorted video path could be loaded as patterns i.e., "myFolder/video-sample-*.mp4"
@@ -128,7 +143,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     for main in mainFiles:
-        myVmaf = vmaf(main, reference, loglevel=loglevel, subsample=n_subsample, model=model, phone= phone, output_fmt=output_fmt, threads=threads, print_progress=print_progress)
+        myVmaf = vmaf(main, reference, loglevel=loglevel, subsample=n_subsample, model=model, phone=phone,
+                      output_fmt=output_fmt, threads=threads, print_progress=print_progress, end_sync=end_sync)
         '''check if syncWin was set. If true offset is computed automatically, otherwise manual values are used  '''
 
         if syncWin > 0:
@@ -145,7 +161,6 @@ if __name__ == '__main__':
         vmafpath = myVmaf.ffmpegQos.vmafpath
         vmafScore = []
 
-        
         if output_fmt == 'json':
             with open(vmafpath) as jsonFile:
                 jsonData = json.load(jsonFile)
@@ -158,7 +173,7 @@ if __name__ == '__main__':
             for frame in root.findall('frames/frame'):
                 value = frame.get('vmaf')
                 vmafScore.append(float(value))
-        
+
         print("\n \n \n \n \n ")
         print("=======================================", flush=True)
         print("VMAF computed", flush=True)
@@ -166,5 +181,5 @@ if __name__ == '__main__':
         print("offset: ", offset, " | psnr: ", psnr)
         print("VMAF score (arithmetic mean): ", mean(vmafScore))
         print("VMAF score (harmonic mean): ", harmonic_mean(vmafScore))
-        print("VMAF output File Path: ", myVmaf.ffmpegQos.vmafpath )
+        print("VMAF output File Path: ", myVmaf.ffmpegQos.vmafpath)
         print("\n \n \n \n \n ")


### PR DESCRIPTION
Adds the program argument argument `endsync`, which adds a [framesync](https://ffmpeg.org/ffmpeg-filters.html#framesync) arg of `shortest=1` to the VMAF filter when set to true.

This is useful in cases where the distorted video might not have exactly the same duration as the reference for some reason, such as the distorted video being captured from a live stream, where frame-perfect duration may be hard to achieve. 